### PR TITLE
LA Audit Fixes

### DIFF
--- a/crates/sodoken/Cargo.toml
+++ b/crates/sodoken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sodoken"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "libsodium wrapper providing tokio safe memory secure api access."
@@ -12,17 +12,17 @@ documentation = "https://docs.rs/sodoken"
 repository = "https://github.com/holochain/sodoken"
 
 [dependencies]
-libc = "0.2.104"
+libc = "0.2.132"
 libsodium-sys = { version = "1.19.22", package = "libsodium-sys-stable" }
-num_cpus = "1.13.0"
-once_cell = "1.8.0"
-one_err = "0.0.5"
-parking_lot = "0.11.2"
-tokio = { version = "1.12.0", features = ["sync", "rt"] }
+num_cpus = "1.13.1"
+once_cell = "1.13.1"
+one_err = "0.0.6"
+parking_lot = "0.12.1"
+tokio = { version = "1.20.1", features = ["sync", "rt"] }
 
 [dev-dependencies]
-criterion = "0.3.5"
-tokio = { version = "1.12.0", features = ["full"] }
+criterion = "0.3.6"
+tokio = { version = "1.20.1", features = ["full"] }
 
 [[bench]]
 name = "blake2b"

--- a/crates/sodoken/src/crypto_box.rs
+++ b/crates/sodoken/src/crypto_box.rs
@@ -65,7 +65,7 @@
 //! ).await.unwrap();
 //!
 //! // receiver decrypts the message
-//! let msg_len = open_easy_msg_len(cipher.len());
+//! let msg_len = cipher.len() - MACBYTES;
 //! let msg = sodoken::BufWrite::new_no_lock(msg_len);
 //! open_easy(
 //!     nonce,

--- a/crates/sodoken/src/crypto_box/curve25519xchacha20poly1305.rs
+++ b/crates/sodoken/src/crypto_box/curve25519xchacha20poly1305.rs
@@ -110,11 +110,6 @@ where
     .await
 }
 
-/// calculate the message len for an easy cipher len
-pub fn open_easy_msg_len(cipher_len: usize) -> usize {
-    cipher_len - MACBYTES
-}
-
 /// decrypt data with box_curve25519xchacha20poly1305_open_easy
 pub async fn open_easy<N, M, C, P, S>(
     nonce: N,
@@ -282,10 +277,8 @@ mod tests {
         .await?;
         assert_ne!(&*msg.read_lock(), &*cipher.read_lock());
 
-        let msg_len =
-            crypto_box::curve25519xchacha20poly1305::open_easy_msg_len(
-                cipher.read_lock().len(),
-            );
+        let msg_len = cipher.read_lock().len()
+            - crypto_box::curve25519xchacha20poly1305::MACBYTES;
         let msg2 = BufWrite::new_no_lock(msg_len);
 
         crypto_box::curve25519xchacha20poly1305::open_easy(
@@ -355,10 +348,8 @@ mod tests {
         .await?;
         assert_ne!(&*msg.read_lock(), &*cipher.read_lock());
 
-        let msg_len =
-            crypto_box::curve25519xchacha20poly1305::open_easy_msg_len(
-                cipher.read_lock().len(),
-            );
+        let msg_len = cipher.read_lock().len()
+            - crypto_box::curve25519xchacha20poly1305::MACBYTES;
         let msg2 = BufWrite::new_no_lock(msg_len);
 
         crypto_box::curve25519xchacha20poly1305::open_easy(

--- a/crates/sodoken/src/crypto_box/curve25519xsalsa20poly1305.rs
+++ b/crates/sodoken/src/crypto_box/curve25519xsalsa20poly1305.rs
@@ -104,11 +104,6 @@ where
     .await
 }
 
-/// calculate the message len for an easy cipher len
-pub fn open_easy_msg_len(cipher_len: usize) -> usize {
-    cipher_len - MACBYTES
-}
-
 /// decrypt data with box_curve25519xsalsa20poly1305_open_easy
 pub async fn open_easy<N, M, C, P, S>(
     nonce: N,
@@ -276,9 +271,8 @@ mod tests {
         .await?;
         assert_ne!(&*msg.read_lock(), &*cipher.read_lock());
 
-        let msg_len = crypto_box::curve25519xsalsa20poly1305::open_easy_msg_len(
-            cipher.read_lock().len(),
-        );
+        let msg_len = cipher.read_lock().len()
+            - crypto_box::curve25519xsalsa20poly1305::MACBYTES;
         let msg2 = BufWrite::new_no_lock(msg_len);
 
         crypto_box::curve25519xsalsa20poly1305::open_easy(
@@ -348,9 +342,8 @@ mod tests {
         .await?;
         assert_ne!(&*msg.read_lock(), &*cipher.read_lock());
 
-        let msg_len = crypto_box::curve25519xsalsa20poly1305::open_easy_msg_len(
-            cipher.read_lock().len(),
-        );
+        let msg_len = cipher.read_lock().len()
+            - crypto_box::curve25519xsalsa20poly1305::MACBYTES;
         let msg2 = BufWrite::new_no_lock(msg_len);
 
         crypto_box::curve25519xsalsa20poly1305::open_easy(

--- a/crates/sodoken/src/secretbox.rs
+++ b/crates/sodoken/src/secretbox.rs
@@ -24,7 +24,7 @@
 //! ).await.unwrap();
 //!
 //! // receiver decrypts the message
-//! let msg_len = open_easy_msg_len(cipher.len());
+//! let msg_len = cipher.len() - MACBYTES;
 //! let msg = sodoken::BufWrite::new_no_lock(msg_len);
 //! open_easy(
 //!     nonce,

--- a/crates/sodoken/src/secretbox/xchacha20poly1305.rs
+++ b/crates/sodoken/src/secretbox/xchacha20poly1305.rs
@@ -45,11 +45,6 @@ where
     .await
 }
 
-/// calculate the message len for an easy cipher len
-pub fn open_easy_msg_len(cipher_len: usize) -> usize {
-    cipher_len - MACBYTES
-}
-
 /// decrypt data with crypto_secretbox_xchacha20poly1305_open_easy
 pub async fn open_easy<N, M, C, K>(
     nonce: N,
@@ -107,9 +102,8 @@ mod tests {
         .await?;
         assert_ne!(&*msg.read_lock(), &*cipher.read_lock());
 
-        let msg_len = secretbox::xchacha20poly1305::open_easy_msg_len(
-            cipher.read_lock().len(),
-        );
+        let msg_len =
+            cipher.read_lock().len() - secretbox::xchacha20poly1305::MACBYTES;
         let msg2 = BufWrite::new_no_lock(msg_len);
 
         secretbox::xchacha20poly1305::open_easy(

--- a/crates/sodoken/src/secretbox/xsalsa20poly1305.rs
+++ b/crates/sodoken/src/secretbox/xsalsa20poly1305.rs
@@ -45,11 +45,6 @@ where
     .await
 }
 
-/// calculate the message len for an easy cipher len
-pub fn open_easy_msg_len(cipher_len: usize) -> usize {
-    cipher_len - MACBYTES
-}
-
 /// decrypt data with crypto_secretbox_xsalsa20poly1305_open_easy
 pub async fn open_easy<N, M, C, K>(
     nonce: N,
@@ -107,9 +102,8 @@ mod tests {
         .await?;
         assert_ne!(&*msg.read_lock(), &*cipher.read_lock());
 
-        let msg_len = secretbox::xsalsa20poly1305::open_easy_msg_len(
-            cipher.read_lock().len(),
-        );
+        let msg_len =
+            cipher.read_lock().len() - secretbox::xsalsa20poly1305::MACBYTES;
         let msg2 = BufWrite::new_no_lock(msg_len);
 
         secretbox::xsalsa20poly1305::open_easy(


### PR DESCRIPTION
Address audit findings:
- Suggestion 1: Update and Maintain Dependencies
  - Updated Dependencies
- Suggestion 3: Make `open_easy_msg_len` Functions Private
  - Just removed those functions - it's easy enough to manually subtract the MACBYTES