### PR TITLE
Switch libsodium crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sodoken changelog
 
-## 0.1.0
+## 0.0.10
+
+- Switch from `libsodium-sys-stable` to `libsodium-sys`. The former is downloading pre-built binaries on Windows which is proving flaky and the latter is deprecated so we shouldn't need to worry about the version of libsodium it installs moving any more.
+
+## 0.0.1
 
 - Initial release

--- a/crates/sodoken/Cargo.toml
+++ b/crates/sodoken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sodoken"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "libsodium wrapper providing tokio safe memory secure api access."
@@ -13,7 +13,7 @@ repository = "https://github.com/holochain/sodoken"
 
 [dependencies]
 libc = "0.2.142"
-libsodium-sys = { version = "1.19.27", package = "libsodium-sys-stable" }
+libsodium-sys = { version = "0.2.7" }
 num_cpus = "1.15.0"
 once_cell = "1.17.1"
 one_err = "0.0.8"


### PR DESCRIPTION
This is causing flaky builds on Windows - https://github.com/holochain/lair/actions/runs/7627099560/job/20774998548?pr=121