### PR TITLE
Add dynamically sized locked array

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Thin wrapper around libsodium-sys-stable.
 use sodoken::*;
 
 let mut pub_key = [0; sign::PUBLICKEYBYTES];
-let mut sec_key = LockedArray::new().unwrap();
+let mut sec_key = SizedLockedArray::new().unwrap();
 
 sign::keypair(&mut pub_key, &mut sec_key.lock()).unwrap();
 

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -10,7 +10,7 @@ fn bench(c: &mut Criterion) {
 
     group.bench_function("keypair", move |b| {
         let mut pk = [0_u8; sodoken::sign::PUBLICKEYBYTES];
-        let mut sk = sodoken::LockedArray::new().unwrap();
+        let mut sk = sodoken::SizedLockedArray::new().unwrap();
         b.iter(move || {
             black_box(sodoken::sign::keypair(&mut pk, &mut sk.lock()).unwrap());
         });
@@ -18,7 +18,7 @@ fn bench(c: &mut Criterion) {
 
     group.bench_function("seed_keypair", move |b| {
         let mut pk = [0_u8; sodoken::sign::PUBLICKEYBYTES];
-        let mut sk = sodoken::LockedArray::new().unwrap();
+        let mut sk = sodoken::SizedLockedArray::new().unwrap();
         b.iter(move || {
             black_box(
                 sodoken::sign::seed_keypair(
@@ -42,7 +42,7 @@ fn bench(c: &mut Criterion) {
             move |b, &size| {
                 let msg = vec![0xdb; size];
                 let mut pk = [0_u8; sodoken::sign::PUBLICKEYBYTES];
-                let mut sk = sodoken::LockedArray::new().unwrap();
+                let mut sk = sodoken::SizedLockedArray::new().unwrap();
                 sodoken::sign::keypair(&mut pk, &mut sk.lock()).unwrap();
                 let mut sig = [0_u8; sodoken::sign::SIGNATUREBYTES];
                 b.iter(move || {
@@ -69,7 +69,7 @@ fn bench(c: &mut Criterion) {
             move |b, &size| {
                 let msg = vec![0xdb; size];
                 let mut pk = [0_u8; sodoken::sign::PUBLICKEYBYTES];
-                let mut sk = sodoken::LockedArray::new().unwrap();
+                let mut sk = sodoken::SizedLockedArray::new().unwrap();
                 sodoken::sign::keypair(&mut pk, &mut sk.lock()).unwrap();
                 let mut sig = [0_u8; sodoken::sign::SIGNATUREBYTES];
                 sodoken::sign::sign_detached(&mut sig, &msg, &sk.lock())

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -15,7 +15,7 @@
 //! // sodoken::random::randombytes_buf(&mut salt).unwrap();
 //!
 //! // generate the pw hash
-//! let mut hash = <sodoken::LockedArray<16>>::new().unwrap();
+//! let mut hash = <sodoken::SizedLockedArray<16>>::new().unwrap();
 //! sodoken::argon2::blocking_argon2id(
 //!     &mut *hash.lock(),
 //!     b"my-passphrase",

--- a/src/crypto_box.rs
+++ b/src/crypto_box.rs
@@ -5,7 +5,7 @@
 //! ```
 //! // recipient has a keypair
 //! let mut pk = [0; sodoken::crypto_box::XSALSA_PUBLICKEYBYTES];
-//! let mut sk = sodoken::LockedArray::new().unwrap();
+//! let mut sk = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::crypto_box::xsalsa_keypair(&mut pk, &mut sk.lock()).unwrap();
 //!
 //! // sender encrypts a message using receiver pub key
@@ -29,12 +29,12 @@
 //! ```
 //! // recipient has a keypair
 //! let mut r_pk = [0; sodoken::crypto_box::XSALSA_PUBLICKEYBYTES];
-//! let mut r_sk = sodoken::LockedArray::new().unwrap();
+//! let mut r_sk = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::crypto_box::xsalsa_keypair(&mut r_pk, &mut r_sk.lock()).unwrap();
 //!
 //! // sender has a keypair
 //! let mut s_pk = [0; sodoken::crypto_box::XSALSA_PUBLICKEYBYTES];
-//! let mut s_sk = sodoken::LockedArray::new().unwrap();
+//! let mut s_sk = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::crypto_box::xsalsa_keypair(&mut s_pk, &mut s_sk.lock()).unwrap();
 //!
 //! // sender encrypts a message

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -5,19 +5,19 @@
 //! ```
 //! // server has a key pair
 //! let mut pk_srv = [0; sodoken::crypto_box::XSALSA_PUBLICKEYBYTES];
-//! let mut sk_srv = sodoken::LockedArray::new().unwrap();
+//! let mut sk_srv = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::crypto_box::xsalsa_keypair(&mut pk_srv, &mut sk_srv.lock())
 //!     .unwrap();
 //!
 //! // client has a keypair
 //! let mut pk_cli = [0; sodoken::crypto_box::XSALSA_PUBLICKEYBYTES];
-//! let mut sk_cli = sodoken::LockedArray::new().unwrap();
+//! let mut sk_cli = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::crypto_box::xsalsa_keypair(&mut pk_cli, &mut sk_cli.lock())
 //!     .unwrap();
 //!
 //! // client can perform a key exchange with just the server pk
-//! let mut cli_rx = sodoken::LockedArray::new().unwrap();
-//! let mut cli_tx = sodoken::LockedArray::new().unwrap();
+//! let mut cli_rx = sodoken::SizedLockedArray::new().unwrap();
+//! let mut cli_tx = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::kx::client_session_keys(
 //!     &mut cli_rx.lock(),
 //!     &mut cli_tx.lock(),
@@ -28,8 +28,8 @@
 //! .unwrap();
 //!
 //! // server can perform a key exchange with just the client pk
-//! let mut srv_rx = sodoken::LockedArray::new().unwrap();
-//! let mut srv_tx = sodoken::LockedArray::new().unwrap();
+//! let mut srv_rx = sodoken::SizedLockedArray::new().unwrap();
+//! let mut srv_tx = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::kx::server_session_keys(
 //!     &mut srv_rx.lock(),
 //!     &mut srv_tx.lock(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! use sodoken::*;
 //!
 //! let mut pub_key = [0; sign::PUBLICKEYBYTES];
-//! let mut sec_key = LockedArray::new().unwrap();
+//! let mut sec_key = SizedLockedArray::new().unwrap();
 //!
 //! sign::keypair(&mut pub_key, &mut sec_key.lock()).unwrap();
 //!

--- a/src/locked_mem.rs
+++ b/src/locked_mem.rs
@@ -1,33 +1,33 @@
 use std::io::{ErrorKind, Result};
 
 /// Locked memory.
-pub struct LockedArray<const N: usize>(*mut libc::c_void);
+pub struct LockedArray(usize, *mut libc::c_void);
 
 // the sodium_malloc-ed c_void is safe to Send
-unsafe impl<const N: usize> Send for LockedArray<N> {}
+unsafe impl Send for LockedArray {}
 
 // note - it might technically be ok it implement Sync,
 // but not to lock/unlock it across threads... so we
 // need to keep the lock function `&mut self` so the
 // Sync wouldn't help usage in any way.
 
-impl<const N: usize> Drop for LockedArray<N> {
+impl Drop for LockedArray {
     fn drop(&mut self) {
         unsafe {
-            libsodium_sys::sodium_free(self.0);
+            libsodium_sys::sodium_free(self.1);
         }
     }
 }
 
-impl<const N: usize> LockedArray<N> {
+impl LockedArray {
     /// Create a new locked memory buffer.
-    pub fn new() -> Result<Self> {
+    pub fn new(size: usize) -> Result<Self> {
         crate::sodium_init();
 
         let z = unsafe {
             // sodium_malloc requires memory-aligned sizes,
             // round up to the nearest 8 bytes.
-            let align_size = (N + 7) & !7;
+            let align_size = (size + 7) & !7;
             let z = libsodium_sys::sodium_malloc(align_size);
             if z.is_null() {
                 return Err(ErrorKind::OutOfMemory.into());
@@ -37,51 +37,133 @@ impl<const N: usize> LockedArray<N> {
             z
         };
 
-        Ok(Self(z))
+        Ok(Self(size, z))
     }
 
     /// Get access to this memory.
-    pub fn lock(&mut self) -> LockedArrayGuard<'_, N> {
+    pub fn lock(&mut self) -> LockedArrayGuard<'_> {
         LockedArrayGuard::new(self)
     }
 }
 
 /// Locked memory that is unlocked for access.
-pub struct LockedArrayGuard<'g, const N: usize>(&'g mut LockedArray<N>);
+pub struct LockedArrayGuard<'g>(&'g mut LockedArray);
 
-impl<'g, const N: usize> LockedArrayGuard<'g, N> {
-    fn new(l: &'g mut LockedArray<N>) -> Self {
+impl<'g> LockedArrayGuard<'g> {
+    fn new(l: &'g mut LockedArray) -> Self {
         unsafe {
-            libsodium_sys::sodium_mprotect_readwrite(l.0);
+            libsodium_sys::sodium_mprotect_readwrite(l.1);
         }
         Self(l)
     }
 }
 
-impl<const N: usize> Drop for LockedArrayGuard<'_, N> {
+impl Drop for LockedArrayGuard<'_> {
     fn drop(&mut self) {
         unsafe {
-            libsodium_sys::sodium_mprotect_noaccess(self.0 .0);
+            libsodium_sys::sodium_mprotect_noaccess(self.0 .1);
         }
     }
 }
 
-impl<const N: usize> std::ops::Deref for LockedArrayGuard<'_, N> {
+impl std::ops::Deref for LockedArrayGuard<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { std::slice::from_raw_parts(self.0 .1 as *const u8, self.0 .0) }
+    }
+}
+
+impl std::ops::DerefMut for LockedArrayGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            std::slice::from_raw_parts_mut(self.0 .1 as *mut u8, self.0 .0)
+        }
+    }
+}
+
+/// Locked memory with a size known at compile time.
+pub struct SizedLockedArray<const N: usize>(LockedArray);
+
+impl<const N: usize> SizedLockedArray<N> {
+    /// Create a new locked memory buffer.
+    pub fn new() -> Result<Self> {
+        Ok(Self(LockedArray::new(N)?))
+    }
+
+    /// Get access to this memory.
+    pub fn lock(&mut self) -> LockedArrayGuardSized<'_, N> {
+        LockedArrayGuardSized::new(self)
+    }
+}
+
+/// Locked memory that is unlocked for access.
+pub struct LockedArrayGuardSized<'g, const N: usize>(LockedArrayGuard<'g>);
+
+impl<'g, const N: usize> LockedArrayGuardSized<'g, N> {
+    fn new(l: &'g mut SizedLockedArray<N>) -> Self {
+        Self(l.0.lock())
+    }
+}
+
+impl<const N: usize> std::ops::Deref for LockedArrayGuardSized<'_, N> {
     type Target = [u8; N];
 
     fn deref(&self) -> &Self::Target {
         unsafe {
-            &*(std::slice::from_raw_parts(self.0 .0 as *const u8, N)[..N]
+            &*(std::slice::from_raw_parts(self.0 .0 .1 as *const u8, N)[..N]
                 .as_ptr() as *const [u8; N])
         }
     }
 }
 
-impl<const N: usize> std::ops::DerefMut for LockedArrayGuard<'_, N> {
+impl<const N: usize> std::ops::DerefMut for LockedArrayGuardSized<'_, N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            &mut *(std::slice::from_raw_parts_mut(self.0 .0 as *mut u8, N)[..N]
+            &mut *(std::slice::from_raw_parts_mut(self.0 .0 .1 as *mut u8, N)
+                [..N]
                 .as_mut_ptr() as *mut [u8; N])
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn use_locked_array_as_array() {
+        let mut locked = LockedArray::new(32).unwrap();
+        locked.lock().copy_from_slice(&[5; 32]);
+
+        fn call_me(input: &[u8]) -> u8 {
+            input[0]
+        }
+        assert_eq!(5, call_me(&*locked.lock()));
+
+        fn call_me_mut(input: &mut [u8]) {
+            input[0] = 8;
+        }
+        call_me_mut(&mut *locked.lock());
+
+        assert_eq!(8, call_me(&*locked.lock()));
+    }
+
+    #[test]
+    fn use_sized_locked_array_as_array() {
+        let mut locked = SizedLockedArray::<32>::new().unwrap();
+        locked.lock().copy_from_slice(&[5; 32]);
+
+        fn call_me(input: &[u8; 32]) -> u8 {
+            input[0]
+        }
+        assert_eq!(5, call_me(&*locked.lock()));
+
+        fn call_me_mut(input: &mut [u8; 32]) {
+            input[0] = 8;
+        }
+        call_me_mut(&mut *locked.lock());
+
+        assert_eq!(8, call_me(&*locked.lock()));
     }
 }

--- a/src/locked_mem.rs
+++ b/src/locked_mem.rs
@@ -46,6 +46,14 @@ impl LockedArray {
     }
 }
 
+impl From<Vec<u8>> for LockedArray {
+    fn from(s: Vec<u8>) -> Self {
+        let mut out = Self::new(s.len()).unwrap();
+        out.lock().copy_from_slice(s.as_slice());
+        out
+    }
+}
+
 /// Locked memory that is unlocked for access.
 pub struct LockedArrayGuard<'g>(&'g mut LockedArray);
 

--- a/src/secretbox.rs
+++ b/src/secretbox.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! // generate a shared secret
-//! let mut s_key = sodoken::LockedArray::new().unwrap();
+//! let mut s_key = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::random::randombytes_buf(&mut *s_key.lock()).unwrap();
 //!
 //! // sender encrypts a message

--- a/src/secretstream.rs
+++ b/src/secretstream.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! // both sides have a secret key
-//! let mut key = sodoken::LockedArray::new().unwrap();
+//! let mut key = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::random::randombytes_buf(&mut *key.lock()).unwrap();
 //!
 //! // -- encryption side -- //
@@ -272,25 +272,25 @@ mod test {
     #[test]
     fn secretstream() {
         let mut p1 = [0; sign::PUBLICKEYBYTES];
-        let mut s1 = LockedArray::new().unwrap();
+        let mut s1 = SizedLockedArray::new().unwrap();
         sign::keypair(&mut p1, &mut s1.lock()).unwrap();
 
         let mut xp1 = [0; kx::PUBLICKEYBYTES];
-        let mut xs1 = LockedArray::new().unwrap();
+        let mut xs1 = SizedLockedArray::new().unwrap();
         sign::pk_to_curve25519(&mut xp1, &p1).unwrap();
         sign::sk_to_curve25519(&mut xs1.lock(), &s1.lock()).unwrap();
 
         let mut p2 = [0; sign::PUBLICKEYBYTES];
-        let mut s2 = LockedArray::new().unwrap();
+        let mut s2 = SizedLockedArray::new().unwrap();
         sign::keypair(&mut p2, &mut s2.lock()).unwrap();
 
         let mut xp2 = [0; kx::PUBLICKEYBYTES];
-        let mut xs2 = LockedArray::new().unwrap();
+        let mut xs2 = SizedLockedArray::new().unwrap();
         sign::pk_to_curve25519(&mut xp2, &p2).unwrap();
         sign::sk_to_curve25519(&mut xs2.lock(), &s2.lock()).unwrap();
 
-        let mut srx = LockedArray::new().unwrap();
-        let mut stx = LockedArray::new().unwrap();
+        let mut srx = SizedLockedArray::new().unwrap();
+        let mut stx = SizedLockedArray::new().unwrap();
         kx::server_session_keys(
             &mut srx.lock(),
             &mut stx.lock(),
@@ -300,8 +300,8 @@ mod test {
         )
         .unwrap();
 
-        let mut crx = LockedArray::new().unwrap();
-        let mut ctx = LockedArray::new().unwrap();
+        let mut crx = SizedLockedArray::new().unwrap();
+        let mut ctx = SizedLockedArray::new().unwrap();
         kx::client_session_keys(
             &mut crx.lock(),
             &mut ctx.lock(),

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -5,7 +5,7 @@
 //! ```
 //! // we have a keypair
 //! let mut pk = [0; sodoken::sign::PUBLICKEYBYTES];
-//! let mut sk = sodoken::LockedArray::new().unwrap();
+//! let mut sk = sodoken::SizedLockedArray::new().unwrap();
 //! sodoken::sign::keypair(&mut pk, &mut sk.lock()).unwrap();
 //!
 //! // we can generate a signature


### PR DESCRIPTION
To support `hc_seed_bundle` creating locked memory from string inputs and combining strings into new locked memory, we need something more dynamic than compile-time sized arrays