### PR TITLE
feat: Clear inputs when copying from moved values into protected memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 [dependencies]
 libc = "0.2.169"
 libsodium-sys = { version = "1.22.2", package = "libsodium-sys-stable" }
+zeroize = "1.8.1"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/locked_mem.rs
+++ b/src/locked_mem.rs
@@ -47,24 +47,22 @@ impl LockedArray {
 }
 
 impl From<Vec<u8>> for LockedArray {
-    fn from(mut s: Vec<u8>) -> Self {
+    fn from(s: Vec<u8>) -> Self {
+        let s = zeroize::Zeroizing::new(s);
+
         let mut out = Self::new(s.len()).unwrap();
         out.lock().copy_from_slice(s.as_slice());
-
-        // clear the input buffer
-        s.fill(0);
 
         out
     }
 }
 
 impl From<Box<[u8]>> for LockedArray {
-    fn from(mut value: Box<[u8]>) -> Self {
+    fn from(value: Box<[u8]>) -> Self {
+        let value = zeroize::Zeroizing::new(value);
+
         let mut out = Self::new(value.len()).unwrap();
         out.lock().copy_from_slice(value.as_ref());
-
-        // clear the input buffer
-        value.fill(0);
 
         out
     }
@@ -191,6 +189,8 @@ mod tests {
         assert_eq!(8, call_me(&*locked.lock()));
     }
 
+    // This test relies on being able to read back memory that has been unallocated.
+    // If this breaks, it may be best to remove it.
     #[test]
     fn clears_input_buffer_from_vec() {
         let mut input = vec![1, 2, 3];
@@ -208,6 +208,8 @@ mod tests {
         assert_eq!(&*locked.lock(), &[1, 2, 3]);
     }
 
+    // This test relies on being able to read back memory that has been unallocated.
+    // If this breaks, it may be best to remove it.
     #[test]
     fn clears_input_buffer_from_box() {
         let input: Box<[u8]> = vec![1, 2, 3].into();


### PR DESCRIPTION
Proposed solution for -> https://github.com/holochain/lair/pull/143#discussion_r1966160844

We take ownership of these values and copy out of them. We can't clear the memory as the caller but it seems like we should always want to when moving into protected memory.