### PR TITLE
chore: Bump version to `0.0.904-alpha`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sodoken"
-version = "0.0.903-alpha"
+version = "0.0.904-alpha"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "libsodium wrapper providing tokio safe memory secure api access."


### PR DESCRIPTION
Bump dev version again, we should probably get everything finished up with Lair before bumping to a release version.