### PR TITLE
chore: update dependabot.yml with shared content

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,28 @@
 version: 2
 
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    groups:
+      background:
+        applies-to: version-updates
+        patterns:
+          - "*"
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      background:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: rust-toolchain
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: weekly
     groups:
-      background:
+      updates:
         applies-to: version-updates
         patterns:
           - "*"
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: weekly
     groups:
-      background:
+      cargo-minor-patch:
         applies-to: version-updates
         patterns:
           - "*"


### PR DESCRIPTION
This PR updates dependeabot.yml with the content from the shared file in the hc-github-config repo.